### PR TITLE
Custom mock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gp
 RUN echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
 RUN apt-get update
 RUN apt-get install -y temurin-21-jre
+RUN apt-get remove -y wget apt-transport-https gpg
 
 COPY --from=build /tmp/node_modules_prod ./node_modules
 COPY --from=build /app/build ./build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,14 @@ services:
     container_name: minecraft
     image: opisek/mc-paper-docker:latest
     volumes:
-      - /srv/minecraft:/app/minecraft # change /srv/minecraft to the directory you want to store minecraft files in
-      - minecraft-data:/app/data
-    network_mode: host
+      - ~/minecraft:/app/minecraft # change /srv/minecraft to the directory you want to store minecraft files in
+    ports: 
+      - 25565:25565
     environment:
-      - EULA=false      # change this to true if you agree to minecraft eula https://www.minecraft.net/en-us/eula
+      - EULA=true      # change this to true if you agree to minecraft eula https://www.minecraft.net/en-us/eula
       - VERSION=latest  # minecraft version or "latest"
-      - CHANNEL=default # change this to experimental for experimental paper builds
-      - GRACE=180       # amount of time in seconds of nobody being online before stopping the server
+      - CHANNEL=experimental # change this to experimental for experimental paper builds
+      - GRACE=10       # amount of time in seconds of nobody being online before stopping the server
       - XMS=8G          # minimum amount of ram to allocate to the server
       - XMX=8G          # maximum amount of ram to allocate to the server
       - UID=9999        # minecraft files user id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,10 @@ services:
     ports: 
       - 25565:25565
     environment:
-      - EULA=true      # change this to true if you agree to minecraft eula https://www.minecraft.net/en-us/eula
+      - EULA=false      # change this to true if you agree to minecraft eula https://www.minecraft.net/en-us/eula
       - VERSION=latest  # minecraft version or "latest"
-      - CHANNEL=experimental # change this to experimental for experimental paper builds
-      - GRACE=10       # amount of time in seconds of nobody being online before stopping the server
+      - CHANNEL=default # change this to experimental for experimental paper builds
+      - GRACE=180       # amount of time in seconds of nobody being online before stopping the server
       - XMS=8G          # minimum amount of ram to allocate to the server
       - XMX=8G          # maximum amount of ram to allocate to the server
       - UID=9999        # minecraft files user id

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "node-fetch": "^3.3.2",
+    "uuid": "^11.0.3",
     "varint": "^6.0.0"
   },
   "type": "module"

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
   "license": "ISC",
   "devDependencies": {
     "@types/node": "^20.4.9",
+    "@types/varint": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^6.3.0",
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "varint": "^6.0.0"
   },
   "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "minecraft-protocol": "^1.47.0",
     "node-fetch": "^3.3.2"
   },
   "type": "module"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { exit } from "process";
-import { Server } from "minecraft-protocol";
 import { ChildProcessWithoutNullStreams } from "child_process";
 
 import acceptEula from "./modules/eula.js";
@@ -7,13 +6,13 @@ import watchServer from "./modules/watcher.js";
 import { getEnvironmental } from "./modules/config.js";
 import { createDirectories } from "./modules/paths.js";
 import { StartupError, runServer } from "./modules/server.js";
-import { handleMockServer, runMockServer } from "./modules/mock.js";
+import { handleMockServer, MockServer, runMockServer } from "./modules/mock.js";
 import { installServer, clearBinariesData } from "./modules/installer.js";
 
 import { Environmental } from "./typings/config.js";
 
 let serverInstance: ChildProcessWithoutNullStreams;
-let mockInstance: Server;
+let mockInstance: MockServer;
 
 async function main(environmental: Environmental) {
   const [ serverBinaries, serverVersion ] = await installServer();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,15 @@
-import { exit } from "process";
 import { ChildProcessWithoutNullStreams } from "child_process";
+import { exit } from "process";
 
 import acceptEula from "./modules/eula.js";
 import watchServer from "./modules/watcher.js";
-import { getEnvironmental } from "./modules/config.js";
-import { createDirectories } from "./modules/paths.js";
 import { StartupError, runServer } from "./modules/server.js";
+import { createDirectories } from "./modules/paths.js";
+import { getEnvironmental } from "./modules/config.js";
 import { handleMockServer, MockServer, runMockServer } from "./modules/mock.js";
 import { installServer, clearBinariesData } from "./modules/installer.js";
 
 import { Environmental } from "./typings/config.js";
-import { pingServer } from "./modules/ping.js";
 
 let serverInstance: ChildProcessWithoutNullStreams;
 let mockInstance: MockServer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,12 +34,12 @@ async function main(environmental: Environmental) {
     }
   }
 
-  await watchServer(environmental, serverInstance);
+  const cachedStatusResponse = await watchServer(environmental, serverInstance);
   serverInstance = null;
   console.log("The server has closed.");
 
   console.log("Starting mock server");
-  mockInstance = await runMockServer(serverVersion);
+  mockInstance = await runMockServer(serverVersion, cachedStatusResponse);
   await handleMockServer(mockInstance);
   mockInstance = null;
   console.log("The mock server has closed.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,15 +56,12 @@ async function shutdown() {
   exit(0);
 }
 
-// TODO: restore after testing is complete
-pingServer("smp.opisek.net", 25565).then(console.log).catch(console.error);
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
 
-//process.on("SIGTERM", shutdown);
-//process.on("SIGINT", shutdown);
-//
-//(async () => {
-//  const environmental = getEnvironmental();
-//  createDirectories();
-//  await acceptEula(environmental.eula);
-//  while (true) await main(environmental);
-//})();
+(async () => {
+  const environmental = getEnvironmental();
+  createDirectories();
+  await acceptEula(environmental.eula);
+  while (true) await main(environmental);
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { handleMockServer, MockServer, runMockServer } from "./modules/mock.js";
 import { installServer, clearBinariesData } from "./modules/installer.js";
 
 import { Environmental } from "./typings/config.js";
+import { pingServer } from "./modules/ping.js";
 
 let serverInstance: ChildProcessWithoutNullStreams;
 let mockInstance: MockServer;
@@ -55,12 +56,15 @@ async function shutdown() {
   exit(0);
 }
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+// TODO: restore after testing is complete
+pingServer("smp.opisek.net", 25565).then(console.log).catch(console.error);
 
-(async () => {
-  const environmental = getEnvironmental();
-  createDirectories();
-  await acceptEula(environmental.eula);
-  while (true) await main(environmental);
-})();
+//process.on("SIGTERM", shutdown);
+//process.on("SIGINT", shutdown);
+//
+//(async () => {
+//  const environmental = getEnvironmental();
+//  createDirectories();
+//  await acceptEula(environmental.eula);
+//  while (true) await main(environmental);
+//})();

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -1,8 +1,8 @@
-import { join } from "path";
 import { UUID } from "crypto";
-import { createReadStream } from "fs";
-import { readFile } from "fs/promises";
 import { createInterface } from "readline";
+import { createReadStream } from "fs";
+import { join } from "path";
+import { readFile } from "fs/promises";
 
 import { minecraft } from "./paths.js";
 

--- a/src/modules/installer.ts
+++ b/src/modules/installer.ts
@@ -1,7 +1,7 @@
-import { join } from "path";
-import { exit } from "process";
 import fetch from "node-fetch";
 import { createWriteStream, existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "fs";
+import { exit } from "process";
+import { join } from "path";
 
 import * as paths from "./paths.js";
 

--- a/src/modules/mock.ts
+++ b/src/modules/mock.ts
@@ -1,12 +1,13 @@
+import * as uuidlib from "uuid";
+import net from "net";
 import { UUID } from "crypto";
 import { existsSync, readFileSync } from "fs";
-import net from "net";
 
 import { getOperators, getPlayerBans, getServerProperties, getWhitelist } from "./config.js";
+import { offlineUUID, parseHandshake, parseLoginStart, parsePacketHeader, serializeLoginDisconnect, serializePongResponse } from "./protocol.js";
+
 import { OperatorEntry, PlayerBanEntry, ServerProperties, WhitelistEntry } from "../typings/config.js";
 import { StatusResponse } from "../typings/protocol.js";
-import { offlineUUID, parseHandshake, parseLoginStart, parsePacketHeader, serializeLoginDisconnect, serializePongResponse } from "./protocol.js";
-import * as uuidlib from "uuid";
 
 function encodeIcon(path: string): string {
   if (!existsSync(path)) return "";

--- a/src/modules/mock.ts
+++ b/src/modules/mock.ts
@@ -45,7 +45,7 @@ export class MockServer {
   start() {
     this.socket = net.createServer();
 
-    this.socket.on("connection", this.handleConnection);
+    this.socket.on("connection", this.handleConnection.bind(this));
 
     // allow the operator to start the real server from the console
     process.stdin.on("data", (message) => {
@@ -58,6 +58,11 @@ export class MockServer {
 
   // TODO: add ip bans too
   handleConnection(socket: net.Socket) {
+    console.log("Player connected to mock server.");
+    socket.on("data", (data) => {
+      console.log(data);
+    });
+    socket.write(this.cachedStatusResponse.raw);
     // TODO: rewrite from scratch
 
     //mockServer.on("login", (client: Client) => {

--- a/src/modules/mock.ts
+++ b/src/modules/mock.ts
@@ -4,7 +4,7 @@ import net from "net";
 
 import { getOperators, getPlayerBans, getServerProperties, getWhitelist } from "./config.js";
 import { OperatorEntry, PlayerBanEntry, ServerProperties, WhitelistEntry } from "../typings/config.js";
-import { StatusResponse } from "src/typings/protocol.js";
+import { StatusResponse } from "../typings/protocol.js";
 import { offlineUUID, parseHandshake, parseLoginStart, parsePacketHeader, serializeLoginDisconnect, serializePongResponse } from "./protocol.js";
 import * as uuidlib from "uuid";
 

--- a/src/modules/mock.ts
+++ b/src/modules/mock.ts
@@ -5,7 +5,7 @@ import net from "net";
 import { getOperators, getPlayerBans, getServerProperties, getWhitelist } from "./config.js";
 import { OperatorEntry, PlayerBanEntry, ServerProperties, WhitelistEntry } from "../typings/config.js";
 import { StatusResponse } from "src/typings/protocol.js";
-import { parseHandshake, parseLoginStart, parsePacketHeader, serializeLoginDisconnect, serializePongResponse } from "./protocol.js";
+import { offlineUUID, parseHandshake, parseLoginStart, parsePacketHeader, serializeLoginDisconnect, serializePongResponse } from "./protocol.js";
 import * as uuidlib from "uuid";
 
 function encodeIcon(path: string): string {
@@ -203,13 +203,12 @@ class ClientConnection {
             // Such a client will be rejected by the the real server later on.
             // This is a known limitation and there are no plans to address it.
 
-            let { name, uuid: rawUuid } = parseLoginStart(payload);
-            if (!this.server.serverProperties.onlineMode) {
-            }
-            const uuid = uuidlib.stringify(rawUuid as Uint8Array) as UUID;
-            console.log(name, uuid);
-
-            console.log(this.server.whitelist);
+            const { name, uuid: rawUuid } = parseLoginStart(payload);
+            const uuid = uuidlib.stringify((
+              this.server.serverProperties.onlineMode ?
+              rawUuid :
+              offlineUUID(name)
+            ) as Uint8Array) as UUID;
 
             // Check whitelist
             if (

--- a/src/modules/mock.ts
+++ b/src/modules/mock.ts
@@ -1,78 +1,135 @@
 import { join } from "path";
 import { UUID } from "crypto";
 import { existsSync, readFileSync } from "fs";
-import { Client, Server, createServer } from "minecraft-protocol";
+import net from "net";
 
 import { minecraft } from "./paths.js";
 import { getOperators, getPlayerBans, getServerProperties, getWhitelist } from "./config.js";
+import { OperatorEntry, PlayerBanEntry, WhitelistEntry } from "../typings/config.js";
 
 function encodeIcon(path: string): string {
   if (!existsSync(path)) return "";
   return "data:image/png;base64," + readFileSync(path).toString("base64");
 }
 
+export class MockServer {
+  serverIp: string;
+  serverPort: number;
+  motd: string;
+  favicon: string;
+  maxPlayers: number;
+  version: string;
+  whitelistEnabled: boolean;
+  whitelist: Map<UUID, WhitelistEntry>;
+  operators: Map<UUID, OperatorEntry>;
+  playerBans: Map<UUID, PlayerBanEntry>;
+
+  socket: net.Server;
+
+  constructor(
+    serverIp: string,
+    serverPort: number,
+    motd: string,
+    favicon: string,
+    maxPlayers: number,
+    version: string,
+    whitelistEnabled: boolean,
+    whitelist: Map<UUID, WhitelistEntry>,
+    operators: Map<UUID, OperatorEntry>,
+    playerBans: Map<UUID, PlayerBanEntry>,
+  ) {
+    this.serverIp = serverIp;
+    this.serverPort = serverPort;
+    this.motd = motd;
+    this.favicon = favicon;
+    this.maxPlayers = maxPlayers;
+    this.version = version;
+    this.whitelistEnabled = whitelistEnabled;
+    this.whitelist = whitelist;
+    this.operators = operators;
+    this.playerBans = playerBans;
+  }
+
+  start() {
+    this.socket = net.createServer();
+
+    this.socket.on("connection", this.handleConnection);
+
+    // allow the operator to start the real server from the console
+    process.stdin.on("data", (message) => {
+      if (message.toString().trim() !== "start") return;
+      this.close();
+    });
+
+    this.socket.listen(this.serverPort, this.serverIp);
+  }
+
+  // TODO: add ip bans too
+  handleConnection(socket: net.Socket) {
+    // TODO: rewrite from scratch
+
+    //mockServer.on("login", (client: Client) => {
+    //  const clientUUID = client.uuid as UUID;
+
+    //  // check whitelist
+    //  if (serverProperties.whitelist && !whitelist.has(clientUUID) && !operators.has(clientUUID)) {
+    //    client.end("You are not whitelisted on this server!");
+    //    return;
+    //  }
+
+    //  // check blacklist
+    //  if (playerBans.has(clientUUID)) {
+    //    const ban = playerBans.get(clientUUID);
+    //    if (ban.expires === "forever" || Date.now() > new Date(ban.expires).getTime()) {
+    //      client.end(`You are banned from this server.\nReason: ${ban.reason}`);
+    //      return;
+    //    }
+    //  }
+
+    //  // TODO: check if there's a way we could handle ipBans as well
+
+    //  // kill the mock
+    //  console.log(`Player ${client.username} attempted to join.`);
+    //  client.end("The server will start shortly. Please join again in a few seconds.");
+    //  stopServer();
+    //});
+  }
+
+  waitForClose() {
+    return new Promise<void>((resolve) => {
+      if (!this.socket) resolve();
+      else this.socket.on("close", resolve);
+    });
+  }
+
+  close() {
+    this.socket.close();
+    process.stdin.removeAllListeners();
+    this.socket = null;
+  }
+}
+
 export async function runMockServer(version: string) {
   const serverProperties = await getServerProperties();
 
-  // online-mode must be disabled
-  // https://github.com/PrismarineJS/node-minecraft-protocol/issues/1289
-  const mockServerOptions = {
-    favicon: encodeIcon(join(minecraft, "server-icon.png")),
-    host: serverProperties.serverIp,
-    motd: serverProperties.motd,
-    "online-mode": false, //serverProperties.onlineMode,
-    port: serverProperties.serverPort,
-    maxPlayers: serverProperties.maxPlayers,
-    version: version,
-  };
+  const mockServer = new MockServer(
+    serverProperties.serverIp,
+    serverProperties.serverPort,
+    serverProperties.motd,
+    encodeIcon(join(minecraft, "server-icon.png")),
+    serverProperties.maxPlayers,
+    version,
+    serverProperties.whitelist,
+    await getWhitelist(),
+    await getOperators(),
+    await getPlayerBans(),
+  );
 
-  // TODO: check if we can respect "enableStatus"
-  return createServer(mockServerOptions);
+  mockServer.start();
+
+  return mockServer;
 }
 
-export async function handleMockServer(mockServer: Server) {
-  const serverProperties = await getServerProperties();
-  const whitelist = await getWhitelist();
-  const operators = await getOperators();
-  const playerBans = await getPlayerBans();
-  //const ipBans = await getIpBans();
-
-  return new Promise<void>((resolve) => {
-    const stopServer = () => {
-      mockServer.close();
-      process.stdin.removeAllListeners();
-      resolve();
-    };
-    
-    mockServer.on("login", (client: Client) => {
-      const clientUUID = client.uuid as UUID;
-
-      // check whitelist
-      if (serverProperties.whitelist && !whitelist.has(clientUUID) && !operators.has(clientUUID)) {
-        client.end("You are not whitelisted on this server!");
-        return;
-      }
-
-      // check blacklist
-      if (playerBans.has(clientUUID)) {
-        const ban = playerBans.get(clientUUID);
-        if (ban.expires === "forever" || Date.now() > new Date(ban.expires).getTime()) {
-          client.end(`You are banned from this server.\nReason: ${ban.reason}`);
-          return;
-        }
-      }
-
-      // TODO: check if there's a way we could handle ipBans as well
-
-      // kill the mock
-      console.log(`Player ${client.username} attempted to join.`);
-      client.end("The server will start shortly. Please join again in a few seconds.");
-      stopServer();
-    });
-
-    process.stdin.on("data", (message) => {
-      if (message.toString().trim() !== "start") return;
-      stopServer();
-    });
-  });
+export function handleMockServer(mockServer: MockServer) {
+  return mockServer.waitForClose();
 }

--- a/src/modules/mock.ts
+++ b/src/modules/mock.ts
@@ -197,6 +197,12 @@ class ClientConnection {
       case 2:
         switch (id) {
           case 0:
+            // IMPORTANT:
+            // User authentication is NOT a responsibility of the mock server.
+            // A manipulated client will be able to start the real server by faking their UUID.
+            // Such a client will be rejected by the the real server later on.
+            // This is a known limitation and there are no plans to address it.
+
             let { name, uuid: rawUuid } = parseLoginStart(payload);
             if (!this.server.serverProperties.onlineMode) {
             }

--- a/src/modules/paths.ts
+++ b/src/modules/paths.ts
@@ -1,5 +1,5 @@
-import { mkdirSync } from "fs";
 import { fileURLToPath } from "url";
+import { mkdirSync } from "fs";
 import { resolve, join, dirname } from "path";
 
 export const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");

--- a/src/modules/ping.ts
+++ b/src/modules/ping.ts
@@ -1,5 +1,7 @@
 import net from "net";
+
 import { parsePacketHeader, parseStatusResponse, serializeHandshake, serializeStatusRequest } from "./protocol.js";
+
 import { StatusResponse } from "../typings/protocol.js";
 
 export const pingServer = async (address: string, port: number): Promise<StatusResponse> => {

--- a/src/modules/ping.ts
+++ b/src/modules/ping.ts
@@ -1,0 +1,36 @@
+import net from "net";
+import { parseStatusResponse, serializeHandshake, serializeStatusRequest } from "./protocol.js";
+
+export const pingServer = async (address: string, port: number): Promise<any> => {
+  const socket = net.createConnection(port, address);
+
+  await new Promise((resolve) => {
+    socket.on("connect", resolve);
+  });
+
+  socket.write(serializeHandshake(769, address, port, 0x01));
+  socket.write(serializeStatusRequest());
+
+  let parseTimeout: NodeJS.Timeout = null;
+  let allData = Buffer.alloc(0);
+
+  return new Promise((resolve, reject) => {
+    socket.on("data", async (data) => {
+      clearTimeout(parseTimeout);
+      allData = Buffer.concat([allData, data]);
+
+      parseTimeout = setTimeout(async () => {
+        const response = await parseStatusResponse(allData);
+        response.raw = data;
+        resolve(response);
+        socket.destroy();
+      }, 100);
+    });
+
+    socket.on("error", (error) => {
+      console.log(error);
+      reject(error);
+      socket.destroy();
+    });
+  });
+}

--- a/src/modules/ping.ts
+++ b/src/modules/ping.ts
@@ -1,7 +1,8 @@
 import net from "net";
 import { parseStatusResponse, serializeHandshake, serializeStatusRequest } from "./protocol.js";
+import { StatusResponse } from "src/typings/protocol.js";
 
-export const pingServer = async (address: string, port: number): Promise<any> => {
+export const pingServer = async (address: string, port: number): Promise<StatusResponse> => {
   const socket = net.createConnection(port, address);
 
   await new Promise((resolve) => {

--- a/src/modules/ping.ts
+++ b/src/modules/ping.ts
@@ -1,6 +1,6 @@
 import net from "net";
 import { parsePacketHeader, parseStatusResponse, serializeHandshake, serializeStatusRequest } from "./protocol.js";
-import { StatusResponse } from "src/typings/protocol.js";
+import { StatusResponse } from "../typings/protocol.js";
 
 export const pingServer = async (address: string, port: number): Promise<StatusResponse> => {
   const socket = net.createConnection(port, address);

--- a/src/modules/ping.ts
+++ b/src/modules/ping.ts
@@ -1,5 +1,5 @@
 import net from "net";
-import { parseStatusResponse, serializeHandshake, serializeStatusRequest } from "./protocol.js";
+import { parsePacketHeader, parseStatusResponse, serializeHandshake, serializeStatusRequest } from "./protocol.js";
 import { StatusResponse } from "src/typings/protocol.js";
 
 export const pingServer = async (address: string, port: number): Promise<StatusResponse> => {
@@ -21,7 +21,8 @@ export const pingServer = async (address: string, port: number): Promise<StatusR
       allData = Buffer.concat([allData, data]);
 
       parseTimeout = setTimeout(async () => {
-        const response = await parseStatusResponse(allData);
+        const { payload } = parsePacketHeader(allData);
+        const response = parseStatusResponse(payload);
         response.raw = data;
         resolve(response);
         socket.destroy();

--- a/src/modules/protocol.ts
+++ b/src/modules/protocol.ts
@@ -1,8 +1,42 @@
-import * as varint from "varint";
+import varint from "varint";
+import { StatusResponse } from "../typings/protocol.js";
 
 export const serializePacket = (id: number, data: Buffer): Buffer => {
-  const length = Buffer.from(varint.encode(data.length));
+  const length = Buffer.from(varint.encode(data.length + 1));
   const packetId = Buffer.from(varint.encode(id));
 
   return Buffer.concat([length, packetId, data]);
+}
+
+export const serializeStatusRequest = (): Buffer => {
+  return Buffer.from([0x01, 0x00]);
+}
+
+export const parseStatusResponse = async (data: Buffer): Promise<StatusResponse> => {
+  const len = varint.decode(data);
+  data = data.subarray(varint.encodingLength(len) + 1); // skip length and packet id
+  const strlen = varint.decode(data);
+  data = data.subarray(varint.encodingLength(strlen)); // skip string length
+  const json = JSON.parse(data.toString());
+  return json;
+}
+
+export const serializeHandshake = (protocolVersion: number, serverAddress: string, serverPort: number, nextState: number): Buffer => {
+  const protocolVersionBuffer = Buffer.from(varint.encode(protocolVersion));
+
+  const serverAddressBuffer = Buffer.from(serverAddress);
+  const serverAddressSize = Buffer.from(varint.encode(serverAddress.length));
+
+  const serverPortBuffer = Buffer.alloc(2);
+  serverPortBuffer.writeUInt16BE(serverPort);
+  
+  const nextStateBuffer = Buffer.from(varint.encode(nextState));
+
+  return serializePacket(0x00, Buffer.concat([
+    protocolVersionBuffer,
+    serverAddressSize,
+    serverAddressBuffer,
+    serverPortBuffer,
+    nextStateBuffer
+  ]));
 }

--- a/src/modules/protocol.ts
+++ b/src/modules/protocol.ts
@@ -1,6 +1,16 @@
 import varint from "varint";
 import { StatusResponse } from "../typings/protocol.js";
 import { UUIDTypes } from "uuid";
+import crypto from "crypto";
+
+export const offlineUUID = (name: string): Buffer => {
+  const hash = crypto.createHash('md5')
+  hash.update(`OfflinePlayer:${name}`, 'utf8')
+  const buffer = hash.digest()
+  buffer[6] = (buffer[6] & 0x0f) | 0x30
+  buffer[8] = (buffer[8] & 0x3f) | 0x80
+  return buffer
+}
 
 export const readLen = (data: Buffer): { length: number, data: Buffer } => {
   const length = varint.decode(data);

--- a/src/modules/protocol.ts
+++ b/src/modules/protocol.ts
@@ -1,7 +1,8 @@
-import varint from "varint";
-import { StatusResponse } from "../typings/protocol.js";
-import { UUIDTypes } from "uuid";
 import crypto from "crypto";
+import varint from "varint";
+import { UUIDTypes } from "uuid";
+
+import { StatusResponse } from "../typings/protocol.js";
 
 export const offlineUUID = (name: string): Buffer => {
   const hash = crypto.createHash('md5')

--- a/src/modules/protocol.ts
+++ b/src/modules/protocol.ts
@@ -1,0 +1,8 @@
+import * as varint from "varint";
+
+export const serializePacket = (id: number, data: Buffer): Buffer => {
+  const length = Buffer.from(varint.encode(data.length));
+  const packetId = Buffer.from(varint.encode(id));
+
+  return Buffer.concat([length, packetId, data]);
+}

--- a/src/modules/server.ts
+++ b/src/modules/server.ts
@@ -1,10 +1,10 @@
-import { join } from "path";
 import { ChildProcessWithoutNullStreams, exec } from "child_process";
+import { join } from "path";
+import { writeFileSync } from "fs";
 
 import { minecraft } from "./paths.js";
 
 import { Environmental } from "../typings/config.js";
-import { writeFileSync } from "fs";
 
 export enum StartupError {
   Corrupted,

--- a/src/modules/watcher.ts
+++ b/src/modules/watcher.ts
@@ -3,6 +3,7 @@ import { ChildProcessWithoutNullStreams } from "child_process";
 import { getServerProperties } from "./config.js";
 
 import { Environmental } from "../typings/config.js";
+import { pingServer } from "./ping.js";
 
 const playerCountRegex = /.*(^|\n)\[[^\]]+\]: There are (\d+) of a max of \d+ players online:.+/;
 
@@ -40,15 +41,11 @@ export default async function watchServer(
     };
 
     const queryPlayerCountByPing = function () {
-      queryPlayerCountByConsole();
-      //minecraftProtocol.default.ping(pingOptions, (error, result) => {
-      //  if (error)
-      //    queryPlayerCountByConsole();
-      //  else if ((result as NewPingResult).players)
-      //    updateOnline((result as NewPingResult).players.online);
-      //  else
-      //    updateOnline((result as OldPingResult).playerCount);
-      //}); 
+      pingServer(pingOptions.host, serverProperties.serverPort).then((response) => {
+        updateOnline(response.players.online);
+      }).catch(() => {
+        queryPlayerCountByConsole();
+      });
     };
 
     const interval = setInterval(

--- a/src/modules/watcher.ts
+++ b/src/modules/watcher.ts
@@ -1,9 +1,10 @@
 import { ChildProcessWithoutNullStreams } from "child_process";
 
-import { Environmental } from "../typings/config.js";
-import { StatusResponse } from "../typings/protocol.js";
 import { getServerProperties } from "./config.js";
 import { pingServer } from "./ping.js";
+
+import { Environmental } from "../typings/config.js";
+import { StatusResponse } from "../typings/protocol.js";
 
 const playerCountRegex = /.*(^|\n)\[[^\]]+\]: There are (\d+) of a max of \d+ players online:.+/;
 

--- a/src/modules/watcher.ts
+++ b/src/modules/watcher.ts
@@ -1,6 +1,4 @@
 import { ChildProcessWithoutNullStreams } from "child_process";
-import { NewPingResult, OldPingResult } from "minecraft-protocol";
-import * as minecraftProtocol from "minecraft-protocol"; // https://github.com/PrismarineJS/node-minecraft-protocol/issues/1253
 
 import { getServerProperties } from "./config.js";
 
@@ -42,14 +40,15 @@ export default async function watchServer(
     };
 
     const queryPlayerCountByPing = function () {
-      minecraftProtocol.default.ping(pingOptions, (error, result) => {
-        if (error)
-          queryPlayerCountByConsole();
-        else if ((result as NewPingResult).players)
-          updateOnline((result as NewPingResult).players.online);
-        else
-          updateOnline((result as OldPingResult).playerCount);
-      }); 
+      queryPlayerCountByConsole();
+      //minecraftProtocol.default.ping(pingOptions, (error, result) => {
+      //  if (error)
+      //    queryPlayerCountByConsole();
+      //  else if ((result as NewPingResult).players)
+      //    updateOnline((result as NewPingResult).players.online);
+      //  else
+      //    updateOnline((result as OldPingResult).playerCount);
+      //}); 
     };
 
     const interval = setInterval(

--- a/src/modules/watcher.ts
+++ b/src/modules/watcher.ts
@@ -1,10 +1,9 @@
 import { ChildProcessWithoutNullStreams } from "child_process";
 
-import { getServerProperties } from "./config.js";
-
 import { Environmental } from "../typings/config.js";
+import { StatusResponse } from "../typings/protocol.js";
+import { getServerProperties } from "./config.js";
 import { pingServer } from "./ping.js";
-import { StatusResponse } from "src/typings/protocol.js";
 
 const playerCountRegex = /.*(^|\n)\[[^\]]+\]: There are (\d+) of a max of \d+ players online:.+/;
 

--- a/src/modules/watcher.ts
+++ b/src/modules/watcher.ts
@@ -19,6 +19,7 @@ export default async function watchServer(
     let lastOnline = Date.now();
 
     const updateOnline = function (playerCount: number) {
+      console.log(playerCount, (Date.now() - lastOnline) / 1000, environmental.gracePeriod); // TODO: remove after testing
       if (playerCount != 0) lastOnline = Date.now();
       else if ((Date.now() - lastOnline) / 1000 >= environmental.gracePeriod) {
         console.log("Shutting the server down due to inactivity.");
@@ -41,7 +42,7 @@ export default async function watchServer(
 
     const queryPlayerCountByPing = function () {
       pingServer(
-        serverProperties.serverIp === "" ? "127.0.0.1" : serverProperties.serverIp,
+        serverProperties.serverIp || "127.0.0.1",
         serverProperties.serverPort
       ).then((response) => {
         // Save the latest ping response (preferably with 0 players online) for replay later

--- a/src/modules/watcher.ts
+++ b/src/modules/watcher.ts
@@ -19,7 +19,6 @@ export default async function watchServer(
     let lastOnline = Date.now();
 
     const updateOnline = function (playerCount: number) {
-      console.log(playerCount, (Date.now() - lastOnline) / 1000, environmental.gracePeriod); // TODO: remove after testing
       if (playerCount != 0) lastOnline = Date.now();
       else if ((Date.now() - lastOnline) / 1000 >= environmental.gracePeriod) {
         console.log("Shutting the server down due to inactivity.");

--- a/src/typings/protocol.d.ts
+++ b/src/typings/protocol.d.ts
@@ -1,0 +1,19 @@
+export type StatusResponse = {
+  version: {
+    name: string,
+    protocol: number
+  },
+  players: {
+    max: number,
+    online: number,
+    sample: {
+      name: string,
+      id: string
+    }[]
+  },
+  description: {
+    text: string
+  },
+  favicon: string,
+  raw: Buffer
+}


### PR DESCRIPTION
Phase out the usage of ``node-minecraft-protocol`` in favor of a custom implementation of the Minecraft protocol.

Care has been taken to make this solution low-maintenance. For this reason, as few packets are possible are exchanged, as little assumptions are possible are made and more complicated packets are replayed instead of constructed from scratch.